### PR TITLE
Someone may have no battery

### DIFF
--- a/root/usr/lib/pacman-auto-update/pacman-auto-update
+++ b/root/usr/lib/pacman-auto-update/pacman-auto-update
@@ -16,7 +16,7 @@ mainFunction () {
 
 batteryIsCharged () {
 	local capacity="/sys/class/power_supply/BAT1/capacity"
-	[[ "${forceUpdate}" -eq 1 ]] || [[ -f "${capacity}" && "$(cat "${capacity}")" -gt 90 ]]
+	[[ "${forceUpdate}" -eq 1 ]] ||	[[ ! -f "${capacity}" || "$(cat "${capacity}")" -gt 90 ]]
 }
 
 


### PR DESCRIPTION
Change logic a little bit so if a system (like a virtual server) hasn't a BAT1/capacity it will still be able to update.
When you haven't a capacity the logic become true, or if it has a capacity, the capacity needs to be greater than 90% to success.